### PR TITLE
Add support for new invoice category keywords

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,13 +127,16 @@ parsed.items = Array.isArray(parsed.items) ? parsed.items : [];
 
 function normalizeCategory(cat, name){
   const t = String(cat || '') + String(name || '');
-  // 優先順：材料→運→手
-  if (/(材料|材)/.test(t)) return '材料費';
-  if (/運/.test(t))        return '運搬費';
-  if (/手/.test(t))        return '手数料';
+  // 優先順：産業廃棄物処理費→人件費→諸経費→材料費→運搬費→手数料
+  if (/(産業?廃棄物処理費?|産)/.test(t)) return '産業廃棄物処理費';
+  if (/(人件費?|人)/.test(t))             return '人件費';
+  if (/(諸経費?|諸)/.test(t))             return '諸経費';
+  if (/(材料|材)/.test(t))                return '材料費';
+  if (/運/.test(t))                       return '運搬費';
+  if (/手/.test(t))                       return '手数料';
 
   // 既に正しい表記ならそのまま
-  const known = ['材料費','運搬費','手数料'];
+  const known = ['産業廃棄物処理費','人件費','諸経費','材料費','運搬費','手数料'];
   if (known.includes(String(cat))) return String(cat);
 
   // いずれにも当てはまらなければデフォルト


### PR DESCRIPTION
## Summary
- extend category normalization to recognise "産", "人", and "諸" inputs
- map the new keywords to the full labels for industrial waste disposal, labour, and miscellaneous expenses
- preserve existing handling for the prior categories

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68cb5ebb775883298bba5bf4a50e3a3c